### PR TITLE
Make SubSequence concretely typed

### DIFF
--- a/src/subsequences.jl
+++ b/src/subsequences.jl
@@ -1,7 +1,7 @@
 using PaddedViews
 
-struct Subsequence
-    c::AbstractVector
+struct Subsequence{VT <: AbstractVector}
+    c::VT
     winlen::Int
     noverlap::Int
     step::Int


### PR DESCRIPTION
This makes access to the data in a SubSequence type stable.